### PR TITLE
Fix: Update code for modern pytest and PyYAML

### DIFF
--- a/matcher/plugin.py
+++ b/matcher/plugin.py
@@ -214,8 +214,8 @@ class _yaml_check_or_store_pattern:
 
         # Load data to compare
         with result_file.open('r') as result_fd, self._expected_file.open('r') as expected_fd:
-            self._result = yaml.load(result_fd)
-            self._expected = yaml.load(expected_fd)
+            self._result = yaml.safe_load(result_fd)
+            self._expected = yaml.safe_load(expected_fd)
 
         return self._result == self._expected
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_requirements_from(filename):
     with (sources_dir() / filename).open(encoding='UTF-8') as f:
         return f.readlines()
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 setup(
     name = 'pytest-matcher'

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -42,7 +42,7 @@ def no_file_test(ourtestdir):
     result = ourtestdir.runpytest()
     result.assert_outcomes(skipped=1)
     result.stdout.re_match_lines([
-        'SKIP \[1\] .*Pattern file not found .*test_no_expected_file.out`'
+        '.*Pattern file not found .*test_no_expected_file.out`'
       ])
 
 
@@ -97,7 +97,7 @@ def result_yaml_not_found_test(ourtestdir):
     result = ourtestdir.runpytest()
     result.assert_outcomes(skipped=1)
     result.stdout.re_match_lines([
-        'SKIP \[1\] .*Result YAML file not found `result.yaml`'
+        '.*Result YAML file not found `result.yaml`'
       ])
 
 
@@ -123,7 +123,7 @@ def expected_yaml_not_found_test(ourtestdir):
     result = ourtestdir.runpytest()
     result.assert_outcomes(skipped=1)
     result.stdout.re_match_lines([
-        'SKIP \[1\] .*Expected YAML file not found `.*test_yaml.yaml`'
+        '.*Expected YAML file not found `.*test_yaml.yaml`'
       ])
 
 


### PR DESCRIPTION
Nowadays `pytest` is 4.4.0 and `PyYAML` 5.1.

This patch fixes deprecation warnings for unsafe loader for PyYAML.
Also, tests have been fixed for changed `pytest` messages.