### PR TITLE
Make plugin fixtures work with parameterized tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,11 @@ name, test class name and/or test function name as following:
 
 ::
 
-    <base-dir>/<test-module-name>/[test-class-name/]<test-function-name>
+    <base-dir>/<test-module-name>/[test-class-name/]<test-function-name>[[<callspec-id>]]
 
 Note, that for non-class test functions the *test-class-name* part is absent.
+For parametrized tests, the *callspec-id* part containing %XX-escaped information
+about the parametrization is added.
 
 
 Quick Start

--- a/matcher/plugin.py
+++ b/matcher/plugin.py
@@ -21,6 +21,7 @@ import platform
 import pytest
 import re
 import shutil
+import urllib.parse
 import yaml
 
 class _content_match_result:
@@ -189,7 +190,7 @@ def _make_expected_filename(request, ext: str, use_system_suffix=True) -> pathli
     if request.cls is not None:
         result /= request.cls.__name__
 
-    result /= request.function.__name__ \
+    result /= urllib.parse.quote(request.node.name, safe='[]') \
       + ('-' + platform.system() if use_system_suffix else '') \
       + ext
 


### PR DESCRIPTION
Closes #4.

While adding the feature, I considered the following things about the resulting pattern filenames:

1. Must contain only valid path characters
2. Must be unique, non-ambiguous for every test

_Also, (3) the filename length must not exceed the limit, but it's not in this PR._

As a result, the plugin will store and read pattern files having the following filename format:

	<test-function-name>[-<callspec>[-<number-suffix>]][-<system-suffix>].<ext>

**Reasoning**

1.  Pytest [escapes](https://github.com/pytest-dev/pytest/blob/c4a356eaee57ebbf70cc336dbe083e3cea47dee5/src/_pytest/compat.py#L190) non-ASCII characters in test IDs. I lean towards POSIX-compliant characters and just to remove non-valid ones. The white spaces are replaced with underscore.

2. After removing the invalid characters, callspec IDs might be non-unique: e.g., [“2*2”, “2+2”] -> [“22”, ”22”]. The solution is to use a numbered suffix added to the callspec part: [“22”, “22-1”]. I’ve added a test for this case to ensure that expectation files are not overwritten during tests.

	(This is only observed for test IDs subject to non-valid characters removing. For a counter-case, e.g., [22, “22”] -> [“220”, “221”], see [this](https://www.github.com/pytest-dev/pytest/issues/663) issue.)

3. There’s no limitation on the length of callspec IDs. With user provided strings, it can easily hit the `PC_NAME_MAX` value. This is not part of this PR, because I think it’s more about the filename itself than parametrization. I’ll create a new one later. As a workaround for now, someone can use [`ids`](https://docs.pytest.org/en/stable/example/parametrize.html#different-options-for-test-ids) argument.

**Mismatch between test IDs and pattern filenames**

With the proposed approach, test IDs in the terminal output don’t match our filenames. However, the pattern filename is printed in mismatch reports for failed tests. As for reporting hooks, the filename can be accessed via plugin fixtures. So, it’s not an issue for me. Even if someone use a special hook, [`pytest_make_parametrize_id`](https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_make_parametrize_id), the pattern filenames will be consistent.
