### PR TITLE
Add option to reveal unused expectations files 

### DIFF
--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -354,13 +354,14 @@ def pytest_configure(config: pytest.Config):
 
 
 class UnusedFilesReporter:
-    """A reporter to reveal and list unused pattern files."""
+    """A reporter to reveal unused pattern files."""
     def pytest_collection_finish(self, session: pytest.Session) -> None:
+        """Once test items have been collected, check for and show unused files."""
         if not session.items:
             return
 
         for alg in [_try_cli_option, _try_ini_option]:
-            patterns_base_dir, _ = alg(session.items[0]._request)
+            patterns_base_dir, _ = alg(session.items[0]._request)  # NOQA: SLF001
             if patterns_base_dir:
                 break
         else:
@@ -372,13 +373,13 @@ class UnusedFilesReporter:
         all_paths: list[pathlib.Path] = []
         for p in patterns_base_dir.rglob('*'):
             if p.is_file() and p.suffix in known_extensions:
-                all_paths.append(p.resolve())
+                all_paths.append(p.resolve())  # NOQA: PERF401
 
         collected_paths: list[pathlib.Path] = []
         for item in session.items:
             for fixture, ext in zip((expected_out, expected_err), known_extensions):
                 if fixture.__name__ in item.fixturenames:
-                    filename = _make_expected_filename(item._request, ext)
+                    filename = _make_expected_filename(item._request, ext)  # NOQA: SLF001
                     collected_paths.append(filename)
 
         unused_paths = set(all_paths).difference(collected_paths)

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -278,6 +278,41 @@ def expected_yaml(request):
       )
 
 
+class UnusedFilesReporter:
+    """A reporter to reveal unused pattern files."""
+    def pytest_collection_finish(self, session: pytest.Session) -> None:
+        """Once test items have been collected, check for and show unused files."""
+        if not session.items:
+            return
+
+        for alg in [_try_cli_option, _try_ini_option]:
+            patterns_base_dir, _ = alg(session.items[0]._request)  # NOQA: SLF001
+            if patterns_base_dir:
+                break
+        else:
+            message = 'Failed to determine a patterns base directory'
+            raise pytest.UsageError(message)
+
+        known_extensions = '.out', '.err'
+
+        all_paths = {
+            p.resolve()
+            for p in patterns_base_dir.rglob('*')
+            if p.is_file() and p.suffix in known_extensions
+          }
+
+        collected_paths = {
+            _make_expected_filename(item._request, ext)  # NOQA: SLF001
+            for item in session.items
+            for fixture, ext in zip((expected_out, expected_err), known_extensions)
+            if fixture.__name__ in item.fixturenames
+          }
+
+        unused_paths = all_paths - collected_paths
+        if unused_paths:
+            sys.stdout.write('\n'.join(map(str, sorted(unused_paths))) + '\n')
+
+
 # BEGIN Pytest hooks
 
 def pytest_assertrepr_compare(op: str, left: object, right: object) -> list[str] | None:  # NOQA: PLR0911
@@ -351,39 +386,5 @@ def pytest_configure(config: pytest.Config):
         reporter = UnusedFilesReporter()
         config.pluginmanager.unregister(name='terminalreporter')
         config.pluginmanager.register(reporter, 'terminalreporter')
-
-
-class UnusedFilesReporter:
-    """A reporter to reveal unused pattern files."""
-    def pytest_collection_finish(self, session: pytest.Session) -> None:
-        """Once test items have been collected, check for and show unused files."""
-        if not session.items:
-            return
-
-        for alg in [_try_cli_option, _try_ini_option]:
-            patterns_base_dir, _ = alg(session.items[0]._request)  # NOQA: SLF001
-            if patterns_base_dir:
-                break
-        else:
-            message = 'Failed to determine a patterns base directory'
-            raise pytest.UsageError(message)
-
-        known_extensions = '.out', '.err'
-
-        all_paths: list[pathlib.Path] = []
-        for p in patterns_base_dir.rglob('*'):
-            if p.is_file() and p.suffix in known_extensions:
-                all_paths.append(p.resolve())  # NOQA: PERF401
-
-        collected_paths: list[pathlib.Path] = []
-        for item in session.items:
-            for fixture, ext in zip((expected_out, expected_err), known_extensions):
-                if fixture.__name__ in item.fixturenames:
-                    filename = _make_expected_filename(item._request, ext)  # NOQA: SLF001
-                    collected_paths.append(filename)
-
-        unused_paths = set(all_paths).difference(collected_paths)
-        if unused_paths:
-            sys.stdout.write('\n'.join(map(str, sorted(unused_paths))) + '\n')
 
 # END Pytest hooks

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -367,8 +367,8 @@ class UnusedFilesReporter:
         known_extensions = '.out', '.err'
 
         all_paths: list[Path] = []
-        for p in patterns_base_dir.iterdir():
-            if p.suffix in known_extensions:
+        for p in patterns_base_dir.rglob('*'):
+            if p.is_file() and p.suffix in known_extensions:
                 all_paths.append(p.resolve())
 
         collected_paths: list[Path] = []

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -383,6 +383,6 @@ class UnusedFilesReporter:
 
         unused_paths = set(all_paths).difference(collected_paths)
         if unused_paths:
-            print('\n'.join(map(str, sorted(unused_paths))))
+            sys.stdout.write('\n'.join(map(str, sorted(unused_paths))) + '\n')
 
 # END Pytest hooks

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -286,7 +286,7 @@ class _UnusedFilesReporter:
             return
 
         for alg in [_try_cli_option, _try_ini_option]:
-            patterns_base_dir, _ = alg(session.items[0]._request)  # NOQA: SLF001
+            patterns_base_dir, _ = alg(session.items[0]._request)  # type: ignore[attr-defined] # NOQA: SLF001
             if patterns_base_dir:
                 break
         else:
@@ -302,10 +302,10 @@ class _UnusedFilesReporter:
           }
 
         collected_paths = {
-            _make_expected_filename(item._request, ext)  # NOQA: SLF001
+            _make_expected_filename(item._request, ext)  # type: ignore[attr-defined] # NOQA: SLF001
             for item in session.items
             for fixture, ext in zip((expected_out, expected_err), known_extensions)
-            if fixture.__name__ in item.fixturenames
+            if fixture.__name__ in item.fixturenames  # type: ignore[attr-defined]
           }
 
         unused_paths = all_paths - collected_paths

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -311,6 +311,7 @@ class _UnusedFilesReporter:
         unused_paths = all_paths - collected_paths
         if unused_paths:
             sys.stdout.write('\n'.join(map(str, sorted(unused_paths))) + '\n')
+            pytest.exit('Found unused pattern files', 1)
 
 
 # BEGIN Pytest hooks

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -387,14 +387,11 @@ def pytest_addoption(parser) -> None:
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config: pytest.Config):
     """Register additional configuration."""
-    if os.getenv('PYTEST_MATCHER_RETURN_CODES', '').lower() == 'yes':  # NOQA: SIM108
-        plugin_return_codes = True
-    else:
-        plugin_return_codes = False
+    return_codes = os.getenv('PYTEST_MATCHER_RETURN_CODES', '').lower() in ('yes', 'true', '1')
 
     if config.getoption('--pm-reveal-unused-files'):
         config.option.collectonly = True
-        reporter = _UnusedFilesReporter(return_codes=plugin_return_codes)
+        reporter = _UnusedFilesReporter(return_codes=return_codes)
         config.pluginmanager.unregister(name='terminalreporter')
         config.pluginmanager.register(reporter, 'terminalreporter')
 

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -387,11 +387,13 @@ def pytest_addoption(parser) -> None:
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config: pytest.Config):
     """Register additional configuration."""
-    if config.getoption('--pm-reveal-unused-files'):
-        return_codes = os.getenv('PYTEST_MATCHER_RETURN_CODES', '').lower() in ('yes', 'true', '1')
-        config.option.collectonly = True
-        reporter = _UnusedFilesReporter(return_codes=return_codes)
-        config.pluginmanager.unregister(name='terminalreporter')
-        config.pluginmanager.register(reporter, 'terminalreporter')
+    if not config.getoption('--pm-reveal-unused-files'):
+        return
+
+    return_codes = os.getenv('PYTEST_MATCHER_RETURN_CODES', '').lower() in ('yes', 'true', '1')
+    config.option.collectonly = True
+    reporter = _UnusedFilesReporter(return_codes=return_codes)
+    config.pluginmanager.unregister(name='terminalreporter')
+    config.pluginmanager.register(reporter, 'terminalreporter')
 
 # END Pytest hooks

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -365,7 +365,7 @@ class UnusedFilesReporter:
                 break
         else:
             message = 'Failed to determine a patterns base directory'
-            raise ValueError(message)
+            raise pytest.UsageError(message)
 
         known_extensions = '.out', '.err'
 

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -278,7 +278,7 @@ def expected_yaml(request):
       )
 
 
-class UnusedFilesReporter:
+class _UnusedFilesReporter:
     """A reporter to reveal unused pattern files."""
     def pytest_collection_finish(self, session: pytest.Session) -> None:
         """Once test items have been collected, check for and show unused files."""
@@ -383,7 +383,7 @@ def pytest_configure(config: pytest.Config):
     """Register additional configuration."""
     if config.getoption('--pm-reveal-unused-files'):
         config.option.collectonly = True
-        reporter = UnusedFilesReporter()
+        reporter = _UnusedFilesReporter()
         config.pluginmanager.unregister(name='terminalreporter')
         config.pluginmanager.register(reporter, 'terminalreporter')
 

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -345,6 +345,7 @@ def pytest_addoption(parser) -> None:
 
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config: pytest.Config):
+    """Register additional configuration."""
     if config.getoption('--pm-reveal-unused-files'):
         config.option.collectonly = True
         reporter = UnusedFilesReporter()
@@ -353,6 +354,7 @@ def pytest_configure(config: pytest.Config):
 
 
 class UnusedFilesReporter:
+    """A reporter to reveal and list unused pattern files."""
     def pytest_collection_finish(self, session: pytest.Session) -> None:
         if not session.items:
             return
@@ -362,16 +364,17 @@ class UnusedFilesReporter:
             if patterns_base_dir:
                 break
         else:
-            raise ValueError('Failed to determine a patterns base directory')
+            message = 'Failed to determine a patterns base directory'
+            raise ValueError(message)
 
         known_extensions = '.out', '.err'
 
-        all_paths: list[Path] = []
+        all_paths: list[pathlib.Path] = []
         for p in patterns_base_dir.rglob('*'):
             if p.is_file() and p.suffix in known_extensions:
                 all_paths.append(p.resolve())
 
-        collected_paths: list[Path] = []
+        collected_paths: list[pathlib.Path] = []
         for item in session.items:
             for fixture, ext in zip((expected_out, expected_err), known_extensions):
                 if fixture.__name__ in item.fixturenames:

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -387,9 +387,8 @@ def pytest_addoption(parser) -> None:
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config: pytest.Config):
     """Register additional configuration."""
-    return_codes = os.getenv('PYTEST_MATCHER_RETURN_CODES', '').lower() in ('yes', 'true', '1')
-
     if config.getoption('--pm-reveal-unused-files'):
+        return_codes = os.getenv('PYTEST_MATCHER_RETURN_CODES', '').lower() in ('yes', 'true', '1')
         config.option.collectonly = True
         reporter = _UnusedFilesReporter(return_codes=return_codes)
         config.pluginmanager.unregister(name='terminalreporter')

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -257,22 +257,23 @@ def parametrized_case_test(ourtestdir) -> None:
 def reveal_unused_files_test(ourtestdir) -> None:
     # Write sample expectation files
     ourtestdir.tmpdir.join('test_a.out').write('')
-    ourtestdir.tmpdir.join('test_b.out').write('')
-    ourtestdir.tmpdir.join('test_b.err').write('')
+    ourtestdir.tmpdir.join('test_a.out.bak').write('')
+    ourtestdir.tmpdir.mkdir('TestClass')
+    ourtestdir.tmpdir.join('TestClass/test_a.out').write('')
     # Write unused files
     ourtestdir.tmpdir.join('test_a.err').write('')
-    ourtestdir.tmpdir.join('test_c.out').write('')
-    ourtestdir.tmpdir.join('test_d.out.bak').write('')
+    ourtestdir.tmpdir.join('test_b.out').write('')
 
     # Write a sample test (finally)
     ourtestdir.makepyfile(f"""
         def test_a(expected_out): pass
-        def test_b(expected_out, expected_err): pass
+        class TestClass:
+            def test_a(self, expected_out): pass
     """)
 
     # Run all tests with pytest
     result = ourtestdir.runpytest('--pm-reveal-unused-files')
     result.stdout.fnmatch_lines([
         ourtestdir.tmpdir.join("test_a.err")
-      , ourtestdir.tmpdir.join("test_c.out")
+      , ourtestdir.tmpdir.join("test_b.out")
       ])

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -254,7 +254,8 @@ def parametrized_case_test(ourtestdir) -> None:
     result.assert_outcomes(passed=3)
 
 
-def reveal_unused_files_test(ourtestdir) -> None:
+@pytest.mark.parametrize(('return_codes', 'expected_code'), [(False, 0), (True, 1)])
+def reveal_unused_files_test(return_codes, expected_code, ourtestdir, monkeypatch) -> None:
     # Write sample expectation files
     ourtestdir.tmpdir.join('test_a.out').write('')
     ourtestdir.tmpdir.join('test_a.out.bak').write('')
@@ -272,8 +273,11 @@ def reveal_unused_files_test(ourtestdir) -> None:
     """)
 
     # Run all tests with pytest
+    if return_codes:
+        monkeypatch.setenv('PYTEST_MATCHER_RETURN_CODES', 'yes')
+
     result = ourtestdir.runpytest('--pm-reveal-unused-files')
-    assert result.ret == 1
+    assert result.ret == expected_code
     result.stdout.fnmatch_lines([
         ourtestdir.tmpdir.join('test_a.err')
       , ourtestdir.tmpdir.join('test_b.out')

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -273,6 +273,7 @@ def reveal_unused_files_test(ourtestdir) -> None:
 
     # Run all tests with pytest
     result = ourtestdir.runpytest('--pm-reveal-unused-files')
+    assert result.ret == 1
     result.stdout.fnmatch_lines([
         ourtestdir.tmpdir.join('test_a.err')
       , ourtestdir.tmpdir.join('test_b.out')

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -265,7 +265,7 @@ def reveal_unused_files_test(ourtestdir) -> None:
     ourtestdir.tmpdir.join('test_b.out').write('')
 
     # Write a sample test (finally)
-    ourtestdir.makepyfile(f"""
+    ourtestdir.makepyfile("""
         def test_a(expected_out): pass
         class TestClass:
             def test_a(self, expected_out): pass
@@ -274,6 +274,6 @@ def reveal_unused_files_test(ourtestdir) -> None:
     # Run all tests with pytest
     result = ourtestdir.runpytest('--pm-reveal-unused-files')
     result.stdout.fnmatch_lines([
-        ourtestdir.tmpdir.join("test_a.err")
-      , ourtestdir.tmpdir.join("test_b.out")
+        ourtestdir.tmpdir.join('test_a.err')
+      , ourtestdir.tmpdir.join('test_b.out')
       ])

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -252,3 +252,27 @@ def parametrized_case_test(ourtestdir) -> None:
     # Run all tests with pytest
     result = ourtestdir.runpytest()
     result.assert_outcomes(passed=3)
+
+
+def reveal_unused_files_test(ourtestdir) -> None:
+    # Write sample expectation files
+    ourtestdir.tmpdir.join('test_a.out').write('')
+    ourtestdir.tmpdir.join('test_b.out').write('')
+    ourtestdir.tmpdir.join('test_b.err').write('')
+    # Write unused files
+    ourtestdir.tmpdir.join('test_a.err').write('')
+    ourtestdir.tmpdir.join('test_c.out').write('')
+    ourtestdir.tmpdir.join('test_d.out.bak').write('')
+
+    # Write a sample test (finally)
+    ourtestdir.makepyfile(f"""
+        def test_a(expected_out): pass
+        def test_b(expected_out, expected_err): pass
+    """)
+
+    # Run all tests with pytest
+    result = ourtestdir.runpytest('--pm-reveal-unused-files')
+    result.stdout.fnmatch_lines([
+        ourtestdir.tmpdir.join("test_a.err")
+      , ourtestdir.tmpdir.join("test_c.out")
+      ])


### PR DESCRIPTION
This adds the `--pm-reveal-unused-files` option to run tests in the collect-only mode and print out the unused expectations files. I find this functionality quite useful to keep a base directory clean after renaming or removing tests. Does it deserve a new plugin option? 

The standard `TerminalReporter` is replaced with a custom reporter to print only revealed unused files separated with newlines—without any headers, summary, etc. The output can be piped to commands like `mv` or `rm`.  Some plugins write reports to files while keeping the default output, but I think in our case it’ll be redundant.

Only files with `.out` and `.err` extensions are checked. This allows to ignore files like README, backup files, etc.

A small question: are the words ‘patterns’ and ‘expectations’ interchangeable? Or ‘patterns’ is a narrow term and refers to expectations containing regexp patterns? Should I rename the option to `--pm-reveal-unused-expectations`?
