### PR TITLE
fix: `<test-module-name>` has never used in an expectation file path

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -16,6 +16,13 @@ to `Semantic Versioning`_.
 Unreleased_
 ===========
 
+Fixed
+-----
+
+- **BREAKING CHANGE** The expectation files path has never used the
+  ``<test-module-name>`` component despite the ``README.rst`` claimed.
+
+
 
 1.6.0_ -- 2024-02-29
 ====================

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -187,6 +187,8 @@ def _make_expected_filename(
     if not result.exists():
         pytest.skip(f'Base directory for pattern-matcher do not exists: `{result}`')
 
+    result /= request.module.__name__.split('.')[-1]
+
     if request.cls is not None:
         result /= request.cls.__name__
 

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+# Standard imports
 import pathlib
 from dataclasses import dataclass
 from typing import Final
 
+# Third party packages
 import pytest
 
 pytest_plugins = ['pytester']


### PR DESCRIPTION
## Changes in this PR

Unfortunately, this is a breaking change… ;-( but definitely has to be fixed!
