### PR TITLE
feat: introduce `pm-pattern-file-fmt` configuration parameter

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -18,8 +18,8 @@ Unreleased_
 
 Added
 -----
-- introduce ``pm-pattern-file-fmt`` configuration parameter to give a full
-  control over path to pattern files.
+- introduce ``pm-pattern-file-fmt`` configuration parameter to give full
+  control over the path to pattern files.
 
 Fixed
 -----

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -27,7 +27,7 @@ Fixed
 - **BREAKING CHANGE** The expectation files path has never used the
   ``<test-module-name>`` component despite the ``README.rst`` claimed.
   Existed projects could set ``pm-pattern-file-fmt`` to
-  ``{class}\{fn}{callspec}{suffix}`` to preserve backward compatibility.
+  ``{class}/{fn}{callspec}{suffix}`` to preserve backward compatibility.
 
 
 1.6.0_ -- 2024-02-29

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -18,7 +18,7 @@ Unreleased_
 
 Added
 -----
-- introduce ``pm-pattern-file-fmt`` configuration parameter to give full
+- Introduce ``pm-pattern-file-fmt`` configuration parameter to give full
   control over the path to pattern files.
 
 Fixed

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -16,12 +16,18 @@ to `Semantic Versioning`_.
 Unreleased_
 ===========
 
+Added
+-----
+- introduce ``pm-pattern-file-fmt`` configuration parameter to give a full
+  control over path to pattern files.
+
 Fixed
 -----
 
 - **BREAKING CHANGE** The expectation files path has never used the
   ``<test-module-name>`` component despite the ``README.rst`` claimed.
-
+  Existed projects could set ``pm-pattern-file-fmt`` to
+  ``{class}\{fn}{callspec}{suffix}`` to preserve backward compatibility.
 
 
 1.6.0_ -- 2024-02-29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ select = ["ALL"]
 "test/test_*.py" = [
     "ANN001"    # Missing type annotation for function argument
   , "D"         # Documentation issues
+  , "PLR0913"   # Too many arguments in function definition
   , "PLR2004"   # Magic value used in comparison
   ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,6 @@ select = ["ALL"]
 "test/test_*.py" = [
     "ANN001"    # Missing type annotation for function argument
   , "D"         # Documentation issues
-  , "PLR0913"   # Too many arguments in function definition
   , "PLR2004"   # Magic value used in comparison
   ]
 

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -343,36 +343,36 @@ def reveal_unused_files_test(return_codes, expected_code, ourtestdir, monkeypatc
 
 
 @pytest.mark.parametrize(
-    ('fmt', 'file_name', 'cls_name', 'fn_name', 'expected_path')
+    ('fmt', 'file_name', 'cls_name', 'expected_path')
   , [
         # Format w/ just a function name produces an expectation file in the base dir
-        ('{fn}',                 'simple_test',     None,      'test_fn', 'test_fn.out')
+        ('{fn}',                 'simple_test',     None,      'test_fn.out')
         # Any leading `/` doesn't produce any files in the FS root
-      , ('/{fn}',                'simple_test',     None,      'test_fn', 'test_fn.out')
+      , ('/{fn}',                'simple_test',     None,      'test_fn.out')
         # Any trailing slashes also ignored
-      , ('{fn}/',                'simple_test',     None,      'test_fn', 'test_fn.out')
+      , ('{fn}/',                'simple_test',     None,      'test_fn.out')
         # Play w/ other components...
-      , ('{module}-{fn}',        'simple_test',     None,      'test_fn', 'simple_test-test_fn.out')
-      , ('{module}/{fn}',        'subdir_test',     None,      'test_fn', 'subdir_test/test_fn.out')
+      , ('{module}-{fn}',        'simple_test',     None,      'simple_test-test_fn.out')
+      , ('{module}/{fn}',        'subdir_test',     None,      'subdir_test/test_fn.out')
         # ... patterns may include some static text
-      , ('py-{module}/exp-{fn}', 'pfx_subdir_test', None,      'test_fn', 'py-pfx_subdir_test/exp-test_fn.out')
+      , ('py-{module}/exp-{fn}', 'pfx_subdir_test', None,      'py-pfx_subdir_test/exp-test_fn.out')
         # Missed class name means no corresponding subdir
-      , ('{class}/{fn}',         'subdir_test',     None,      'test_fn', 'test_fn.out')
+      , ('{class}/{fn}',         'subdir_test',     None,      'test_fn.out')
         # Missed class name in the format is Ok
-      , ('{fn}',                 'simple_test',     'TestCls', 'test_fn', 'test_fn.out')
+      , ('{fn}',                 'simple_test',     'TestCls', 'test_fn.out')
         # Play w/ other components...
-      , ('{class}+{fn}',         'simple_test',     'TestCls', 'test_fn', 'TestCls+test_fn.out')
-      , ('{module}/{class}/{fn}','simple_test',     'TestCls', 'test_fn', 'simple_test/TestCls/test_fn.out')
+      , ('{class}+{fn}',         'simple_test',     'TestCls', 'TestCls+test_fn.out')
+      , ('{module}/{class}/{fn}','simple_test',     'TestCls', 'simple_test/TestCls/test_fn.out')
         # Redundant '/' just ignored
-      , ('{module}//{class}//{fn}','simple_test',   'TestCls', 'test_fn', 'simple_test/TestCls/test_fn.out')
+      , ('{module}//{class}//{fn}','simple_test',   'TestCls', 'simple_test/TestCls/test_fn.out')
         # '.' is meaningless
-      , ('./{class}/{fn}',         'simple_test',   'TestCls', 'test_fn', 'TestCls/test_fn.out')
-      , ('{class}/./{fn}',         'simple_test',   'TestCls', 'test_fn', 'TestCls/test_fn.out')
+      , ('./{class}/{fn}',         'simple_test',   'TestCls', 'TestCls/test_fn.out')
+      , ('{class}/./{fn}',         'simple_test',   'TestCls', 'TestCls/test_fn.out')
         # Directory traversal also ignored
-      , ('../{class}/../{fn}',     'simple_test',   'TestCls', 'test_fn', 'TestCls/test_fn.out')
+      , ('../{class}/../{fn}',     'simple_test',   'TestCls', 'TestCls/test_fn.out')
     ]
   )
-def fn_fmt_test(pytester: pytest.Pytester, fmt, file_name, cls_name, fn_name, expected_path) -> None:
+def fn_fmt_test(pytester: pytest.Pytester, fmt, file_name, cls_name, expected_path) -> None:
     # Write a sample config file
     pytester.makefile(
         '.ini'
@@ -393,7 +393,7 @@ def fn_fmt_test(pytester: pytest.Pytester, fmt, file_name, cls_name, fn_name, ex
     indent = ' ' * (4 if cls_name is not None else 0)
     kwargs = {file_name: f"""
         {('class ' + cls_name + ':') if cls_name is not None else ''}
-        {indent}def {fn_name}({'self, ' if cls_name is not None else ''}capfd, expected_out):
+        {indent}def test_fn({'self, ' if cls_name is not None else ''}capfd, expected_out):
         {indent}    print('Hello Africa!', end='')
         {indent}    stdout, stderr = capfd.readouterr()
         {indent}    assert expected_out == stdout


### PR DESCRIPTION
## Changes in this PR

The format string may have the following placeholders:
- `{module}`
- `{class}`
- `{fn}`
- `{callspec}`
- `{suffix}`

Default value is: `{module}/{class}/{fn}{callspec}{suffix}`. Set it to `{class}/{fn}{callspec}{suffix}` can help existing code to preserve backward compatibility broken by PR #19.
