### PR TITLE
impr: drop `pm-pattern-file-use-system-name` configuration option

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -27,7 +27,14 @@ Fixed
 - **BREAKING CHANGE** The expectation files path has never used the
   ``<test-module-name>`` component despite the ``README.rst`` claimed.
   Existed projects could set ``pm-pattern-file-fmt`` to
-  ``{class}/{fn}{callspec}{suffix}`` to preserve backward compatibility.
+  ``{class}/{fn}{callspec}`` to preserve backward compatibility.
+
+Removed
+-------
+
+- **BREAKING CHANGE** The ``pm-pattern-file-use-system-name`` configuration
+  parameter has been removed. Having ``{suffix}`` in the ``pm-pattern-file-fmt``
+  one can have a system name suffix whenever he needs it.
 
 
 1.6.0_ -- 2024-02-29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ select = ["ALL"]
 "test/test_*.py" = [
     "ANN001"    # Missing type annotation for function argument
   , "D"         # Documentation issues
+  , "PLR0913"   # Too many arguments in function definition
   , "PLR2004"   # Magic value used in comparison
   ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,6 @@ select = ["ALL"]
 "test/test_*.py" = [
     "ANN001"    # Missing type annotation for function argument
   , "D"         # Documentation issues
-  , "PLR0913"   # Too many arguments in function definition
   , "PLR2004"   # Magic value used in comparison
   ]
 

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -177,12 +177,6 @@ def _make_expected_filename(
 
     assert result is not None
 
-    use_system_suffix = (
-        request.config.getini('pm-pattern-file-use-system-name')
-        if can_use_system_suffix
-        else False
-      )
-
     # Make the found path absolute using pytest's rootdir as the base
     if not result.is_absolute():
         if use_cwd_as_base:
@@ -205,7 +199,7 @@ def _make_expected_filename(
             request.node.name[len(request.function.__name__):]
           , safe='[]'
           )
-      , 'suffix': '-' + platform.system() if use_system_suffix else ''
+      , 'suffix': '-' + platform.system() if can_use_system_suffix else ''
       }
 
     return functools.reduce(
@@ -392,16 +386,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
       , default=None
       )
     parser.addini(
-        'pm-pattern-file-use-system-name'
-      , help='expect a system name (`platform.system()`) to be a pattern filename suffix'
-      , type='bool'
-      , default=False
-      )
-    parser.addini(
         'pm-pattern-file-fmt'
       , help='pattern filename format can use placeholders: `module`, `class`, `fn`, `callspec`, `system`'
       , type='string'
-      , default='{module}/{class}/{fn}{callspec}{suffix}'
+      , default='{module}/{class}/{fn}{callspec}'
       )
 
 


### PR DESCRIPTION
## Changes in this PR

Having ``{suffix}`` in the ``pm-pattern-file-fmt`` one can have a system name suffix whenever he needs it.
