### PR TITLE
feat(#22): support marking tests with `@pytest.mark.expect_suffix`

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -20,6 +20,10 @@ Added
 -----
 - Introduce ``pm-pattern-file-fmt`` configuration parameter to give full
   control over the path to pattern files.
+- Test can be marked with ``@pytest.mark.expect_suffix([args..., suffix=<arg>])``
+  to have an arbitrary suffix in the pattern filenames.
+  The ``pm-pattern-file-fmt`` format string should have the ``{suffix}`` placeholder
+  to make it work. See issue #22.
 
 Fixed
 -----

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -20,7 +20,7 @@ Added
 -----
 - Introduce ``pm-pattern-file-fmt`` configuration parameter to give full
   control over the path to pattern files.
-- Test can be marked with ``@pytest.mark.expect_suffix([args..., suffix=<arg>])``
+- A test can be marked with ``@pytest.mark.expect_suffix([args..., suffix=<arg>])``
   to have an arbitrary suffix in the pattern filenames.
   The ``pm-pattern-file-fmt`` format string should have the ``{suffix}`` placeholder
   to make it work. See issue #22.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ select = ["ALL"]
 "test/test_*.py" = [
     "ANN001"    # Missing type annotation for function argument
   , "D"         # Documentation issues
+  , "PLR0913"   # Too many arguments in function definition
   , "PLR2004"   # Magic value used in comparison
   ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,6 @@ select = ["ALL"]
 "test/test_*.py" = [
     "ANN001"    # Missing type annotation for function argument
   , "D"         # Documentation issues
-  , "PLR0913"   # Too many arguments in function definition
   , "PLR2004"   # Magic value used in comparison
   ]
 

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -391,6 +391,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
       , type='string'
       , default='{module}/{class}/{fn}{callspec}'
       )
+    parser.addini(
+        'pm-pattern-file-fmt'
+      , help='pattern filename format can use placeholders: `module`, `class`, `fn`, `callspec`, `system`'
+      , type='string'
+      , default='{module}/{class}/{fn}{callspec}{suffix}'
+      )
 
 
 @pytest.hookimpl(trylast=True)


### PR DESCRIPTION
## Changes in this PR

A test can be marked with `@pytest.mark.expect_suffix([args..., suffix=<arg>])` to have an arbitrary suffix in the pattern filenames. The `pm-pattern-file-fmt` format string should have the `{suffix}` placeholder to make it work.
