### PR TITLE
Expand a list of EOLs to be shown in the `full` mismatch mode

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -35,6 +35,7 @@ Added
   to make it work. See :issue:`22`.
 - `Documentation`_.
 - Introduce :option:`pm-mismatch-style`.
+- Show newlines in the ``full`` mismatch mode.
 
 Fixed
 -----

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -41,6 +41,8 @@ except ImportError:
 
 PM_COLOR_OUTPUT = pytest.StashKey[bool]()
 
+_EOL_RE = re.compile('(\r?\n|\r)')
+
 if sys.version_info < (3, 11):
     _RE_NOFLAG: Final[re.RegexFlag] = cast(re.RegexFlag, 0)
 else:
@@ -147,17 +149,21 @@ class _ContentCheckOrStorePattern:
           , filename=self._pattern_filename
           )
 
+    def _make_newlines_visible(self, text: str) -> str:
+        return _EOL_RE.sub(r'↵\1', text)
+
     def _report_mismatch_text(self, actual: str, *, color: bool) -> list[str]:  # NOQA: ARG002
         assert self._expected_file_content is not None
+        expected = self._expected_file_content
         return [
             ''
           , "The test output doesn't equal to the expected"
           , f'(from `{self._pattern_filename}`):'
           , '---[BEGIN actual output]---'
-          , *actual.replace('\n','↵\n').splitlines()
+          , *self._make_newlines_visible(actual).splitlines()
           , '---[END actual output]---'
           , '---[BEGIN expected output]---'
-          , *self._expected_file_content.replace('\n','↵\n').splitlines()
+          , *self._make_newlines_visible(expected).splitlines()
           , '---[END expected output]---'
           ]
 
@@ -166,8 +172,8 @@ class _ContentCheckOrStorePattern:
         expected = self._expected_file_content
         diff=[
             *difflib.unified_diff(
-                expected.replace('\n','↵\n').splitlines()
-              , actual.replace('\n','↵\n').splitlines()
+                self._make_newlines_visible(expected).splitlines()
+              , self._make_newlines_visible(actual).splitlines()
               , fromfile='expected'
               , tofile='actual'
               , lineterm=''

--- a/src/matcher/plugin.py
+++ b/src/matcher/plugin.py
@@ -41,7 +41,7 @@ except ImportError:
 
 PM_COLOR_OUTPUT = pytest.StashKey[bool]()
 
-_EOL_RE = re.compile('(\r?\n|\r)')
+_EOL_RE: Final[re.Pattern] = re.compile('(\r?\n|\r)')
 
 if sys.version_info < (3, 11):
     _RE_NOFLAG: Final[re.RegexFlag] = cast(re.RegexFlag, 0)

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -46,16 +46,17 @@ def simple_test(ourtestdir, expectdir) -> None:
     result.assert_outcomes(passed=1)
 
 
-def failed_test(ourtestdir, expectdir) -> None:
+@pytest.mark.parametrize('eol', [r'\r', r'\n', r'\r\n'])
+def failed_test(eol, ourtestdir, expectdir) -> None:
     # Write a sample expectations file
     expectdir.makepatternfile('.out', test_not_matched='Hello Africa!')
     # Write a sample test
-    ourtestdir.makepyfile("""
+    ourtestdir.makepyfile(f"""
         def test_not_matched(capfd, expected_out):
-            print('Unexpected output')
+            print('Unexpected output', end='{eol}')
             stdout, stderr = capfd.readouterr()
             assert expected_out == stdout
-      """
+        """
     )
 
     # Run all tests with pytest


### PR DESCRIPTION
## Changes in this PR

Expand a list of EOLs to be shown in the `full` mismatch mode to three most common line endings: `\r`, `\n`, `\r\n`. This makes mismatch reporting work as intended on different platforms or when a custom text containing these characters is tested.
