### PR TITLE
impr(ci): avoid full `pyproject.toml` hashing for GHA cache key

### DIFF
--- a/.github/workflows/get-key.py
+++ b/.github/workflows/get-key.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: 2024-now, Alex Turbov <zaufi@pm.me>
+# SPDX-License-Identifier: CC0-1.0
 
 """Print any key from TOML file."""
 

--- a/.github/workflows/get-key.py
+++ b/.github/workflows/get-key.py
@@ -11,7 +11,10 @@ import json
 import pathlib
 import sys
 
-import tomllib
+try:
+  import tomllib
+except ImportError:
+  import tomli as tomllib
 
 
 def main() -> None:

--- a/.github/workflows/get-key.py
+++ b/.github/workflows/get-key.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+"""Print any key from TOML file."""
+
+import argparse
+import functools
+import hashlib
+import json
+import pathlib
+import sys
+
+import tomllib
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description='Access nested data of a TOML file using dot-separated keys.'
+      )
+    parser.add_argument(
+        '--file-path'
+      , type=str
+      , default='pyproject.toml', help='Path to the TOML file'
+      )
+    parser.add_argument(
+        'keys'
+      , type=str
+      , help='Dot-separated keys to access nested data'
+      )
+    parser.add_argument(
+        '--hash'
+      , action='store_true'
+      , help='Print the SHA-1 hash of the found value instead of plain output'
+      )
+    parser.add_argument(
+        '--json'
+      , action='store_true'
+      , help='Print the value as JSON'
+      )
+
+    args = parser.parse_args()
+
+    with pathlib.Path.open(args.file_path, 'rb') as fd:
+        data = tomllib.load(fd)
+
+    try:
+        selected_key = functools.reduce(
+            lambda state, part: state[part]
+          , args.keys.split('.')
+          , data
+          )
+        if args.json:
+          result = json.dumps(selected_key, indent=2)
+        else:
+          match selected_key:
+            case str():
+              result = selected_key
+            case list():
+              if all(isinstance(v, str) for v in selected_key):
+                result = '\n'.join(selected_key)
+              else:
+                # TODO Don't care for now!
+                msg = 'Some items of the selected key are not strings'
+                raise TypeError(msg)
+            case _:
+              print(f"Error: Dunno how to print key '{args.keys}' of type {type(selected_key).__name__}.")
+              sys.exit(1)
+
+        if args.hash:
+            print(hashlib.sha1(str(result).encode()).hexdigest())
+        else:
+            print(result)
+
+    except TypeError as e:
+        print(f'Error: {e}.')
+        sys.exit(1)
+
+    except KeyError as e:
+        print(f"Error: Given key {e} not found in the '{args.file_path}'.")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/get-key.py
+++ b/.github/workflows/get-key.py
@@ -8,7 +8,6 @@ import argparse
 import functools
 import hashlib
 import json
-import pathlib
 import sys
 
 try:
@@ -45,7 +44,7 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    with pathlib.Path.open(args.file_path, 'rb') as fd:
+    with open(args.file_path, 'rb') as fd:
         data = tomllib.load(fd)
 
     try:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -24,11 +24,17 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Get Cache Key
+        run: |
+          echo "CACHE_KEY=$( \
+              .github/workflows/get-key.py --hash tool.hatch.envs.default.dependencies \
+            )" | tee -a "${GITHUB_ENV}"
+        shell: bash
+
       - name: Prepare Cache
         uses: actions/cache@v4
         with:
-          # TODO Hashing the whole `pyproject.toml` isn't nice!
-          key: py3.12-hatch-${{ hashFiles('pyproject.toml') }}-lint
+          key: py3.12-hatch-${{ env.CACHE_KEY }}-lint
           path: |
             ~/.cache/pip
             ~/.local/share/hatch

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Get Cache Key
         run: |
           echo "CACHE_KEY=$( \
@@ -38,11 +43,6 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.local/share/hatch
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -30,11 +30,18 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Get Cache Key
+        run: |
+          echo "CACHE_KEY=$( \
+              .github/workflows/get-key.py --json --hash tool.hatch.envs.test.overrides.matrix.pytest.dependencies \
+            )" | tee -a "${GITHUB_ENV}"
+
+        shell: bash
       - name: Prepare Cache
         uses: actions/cache@v4
         with:
           # TODO Hashing the whole `pyproject.toml` isn't nice!
-          key: py${{ matrix.python-version }}-hatch-${{ hashFiles('pyproject.toml') }}-tests
+          key: py${{ matrix.python-version }}-hatch-${{ env.CACHE_KEY }}-tests
           path: |
             ~/.cache/pip
             ~/.local/share/hatch

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -40,8 +40,8 @@ jobs:
           echo "CACHE_KEY=$( \
               .github/workflows/get-key.py --json --hash tool.hatch.envs.test.overrides.matrix.pytest.dependencies \
             )" | tee -a "${GITHUB_ENV}"
-
         shell: bash
+
       - name: Prepare Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Get Cache Key
         run: |
+          [[ '${{ matrix.python-version }}' == '3.10' ]] && pip install tomli
           echo "CACHE_KEY=$( \
               .github/workflows/get-key.py --json --hash tool.hatch.envs.test.overrides.matrix.pytest.dependencies \
             )" | tee -a "${GITHUB_ENV}"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -30,6 +30,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Get Cache Key
         run: |
           echo "CACHE_KEY=$( \
@@ -45,11 +50,6 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.local/share/hatch
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,8 @@ select = ["ALL"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 ".github/workflows/get-key.py" = [
-    "S324"      # Probable use of insecure hash functions in `hashlib`: `sha1`
+    "PTH123"    # `open()` should be replaced by `Path.open()`
+  , "S324"      # Probable use of insecure hash functions in `hashlib`: `sha1`
   , "T201"      # `print` found
   , "TRY301"    # Abstract `raise` to an inner function
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ all = [
 dead-check = "vulture src/pytest_matcher"
 dist-check = "twine check dist/*"
 license-check = "reuse lint"
-lint-check = "ruff check src/pytest_matcher test"
+lint-check = "ruff check .github/workflows/get-key.py doc src/pytest_matcher test"
 pyproject-check = "validate-pyproject {root:real}/pyproject.toml"
 spell-check = "codespell"
 type-check = "mypy src/pytest_matcher test"
@@ -232,6 +232,11 @@ ignore = [
 select = ["ALL"]
 
 [tool.ruff.lint.extend-per-file-ignores]
+".github/workflows/get-key.py" = [
+    "S324"      # Probable use of insecure hash functions in `hashlib`: `sha1`
+  , "T201"      # `print` found
+  , "TRY301"    # Abstract `raise` to an inner function
+  ]
 "doc/conf.py" = [
     "INP001"
   , "D100"      # Missing docstring in public module


### PR DESCRIPTION
## Changes in this PR

Hashing the whole `pyproject.toml` is convenient but leads to too frequent cache stale events (literally after any changes in the mentioned file). However, dependencies are not changed frequently in fact!

<!--
Thanks for your interest in contributing to this repository!
Please describe your changes here.
-->
