### PR TITLE
Don't override the path suffix-like part by a pattern filename extension

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -35,6 +35,8 @@ Fixed
 -----
 
 - Release GitHub workflow has been fixed to use modern versions of involved actions.
+- Do not override the path suffix-like part (separated by a dot) with a pattern
+  filename extension.
 
 
 2.0.0_ -- 2024-03-11

--- a/src/pytest_matcher/plugin.py
+++ b/src/pytest_matcher/plugin.py
@@ -262,11 +262,12 @@ def _make_expected_filename(request: pytest.FixtureRequest, ext: str) -> pathlib
       , 'suffix': ('','-')[int(bool(args))] + urllib.parse.quote('-'.join(args), safe='[]')
       }
 
-    return functools.reduce(
+    result = functools.reduce(
         functools.partial(_subst_pattern_parts, **subst)
       , pathlib.Path(request.config.getini('pm-pattern-file-fmt')).parts
       , result
-      ).with_suffix(ext)
+      )
+    return result.with_suffix(result.suffix + ext)
 
 
 @pytest.fixture()

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -239,6 +239,7 @@ def parametrized_case_test(ourtestdir, expectdir) -> None:
         ((0, 'y'), '[0-y]'),
         ((1, 'some words'), '[1-some%20words]'),
         ((2, '~/some/path/'), '[2-~%2Fsome%2Fpath%2F]'),
+        ((3, 'with.dot'), '[3-with.dot]'),
     ]
     # Write sample expectation files
     for values, decoration in testing_pairs:
@@ -258,7 +259,7 @@ def parametrized_case_test(ourtestdir, expectdir) -> None:
 
     # Run all tests with pytest
     result = ourtestdir.runpytest()
-    result.assert_outcomes(passed=3)
+    result.assert_outcomes(passed=4)
 
 
 @pytest.mark.parametrize(('return_codes', 'expected_code'), [(False, 0), (True, 1)])
@@ -384,6 +385,7 @@ def pm_pattern_file_fmt_directory_traversal_test(pytester: pytest.Pytester) -> N
         ('', f'test_sfx-{platform.system()}.out')
         # Positional arg marker
       , ('platform.system()', f'test_sfx-{platform.system()}.out')
+      , ('"with.dot"', 'test_sfx-with.dot.out')
         # Positional args marker
       , (
             '"py", f"{sys.version_info.major}", platform.system()'


### PR DESCRIPTION
## Changes in this PR

Fix the case where the ending path suffix-like part (separated by a dot) was overwritten by a pattern filename extension. For example, without these changes, the `test_example[with.dot]` node ID is incorrectly transformed to the `test_example[with.out` filename. Tests with parameters, suffixes, and custom pattern filenames are affected by that.
