### PR TITLE
Improve --pm-save-patterns help text

### DIFF
--- a/src/pytest_matcher/plugin.py
+++ b/src/pytest_matcher/plugin.py
@@ -441,8 +441,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     group.addoption(
         '--pm-save-patterns'
       , action='store_true'
-        # TODO Better description
-      , help='store matching patterns instead of checking them'
+      , help='write captured output to pattern files and skip the test'
       )
     group.addoption(
         '--pm-mismatch-style'


### PR DESCRIPTION
## Summary
- clarify the description for the `--pm-save-patterns` option

## Testing
- `pre-commit run --files src/pytest_matcher/plugin.py`
- `pytest -q` *(fails: directory traversal test)*

------
https://chatgpt.com/codex/tasks/task_b_686ee75a4ad48323aeaa75d2c79452cd