### PR TITLE
Use dataclass for ContentMatchResult

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,9 +256,6 @@ select = ["ALL"]
   , "D100"      # Missing docstring in public module
   , "A001"      # Variable `copyright` is shadowing a Python builtin
   ]
-"src/pytest_matcher/plugin.py" = [
-    "PLW1641"   # TODO Remove after PR #36 gets merged
-  ]
 "test/test_*.py" = [
     "ANN001"    # Missing type annotation for function argument
   , "D"         # Documentation issues

--- a/src/pytest_matcher/plugin.py
+++ b/src/pytest_matcher/plugin.py
@@ -19,6 +19,7 @@ import shutil
 import sys
 import urllib.parse
 from typing import Final, TextIO, cast
+from dataclasses import dataclass
 
 # Third party packages
 import pytest
@@ -54,33 +55,31 @@ class _MismatchStyle(enum.Enum):
     DIFF = enum.auto()
 
 
+@dataclass
 class _ContentMatchResult:
-    """TODO Is this job for Python `dataclass`?"""
+    """Result of matching text content against a regex."""
 
-    def __init__(self, *, result: bool, text: list[str], regex: str, filename: pathlib.Path) -> None:
-        self._result = result
-        self._text = text
-        self._regex = regex
-        self._filename = filename
+    result: bool
+    text: list[str]
+    regex: str
+    filename: pathlib.Path
 
     def __eq__(self, other: object) -> bool:
-        if isinstance(other, bool):
-            return self._result == other
-        return False
+        return isinstance(other, bool) and self.result == other
 
     def __bool__(self) -> bool:
-        return self._result
+        return self.result
 
     def report_regex_mismatch(self) -> list[str]:
         return [
             ''
           , "The test output doesn't match to the expected regex"
-          , f'(from `{self._filename}`):'
+          , f'(from `{self.filename}`):'
           , '---[BEGIN actual output]---'
-          , *self._text
+          , *self.text
           , '---[END actual output]---'
           , '---[BEGIN expected regex]---'
-          , *self._regex.splitlines()
+          , *self.regex.splitlines()
           , '---[END expected regex]---'
           ]
 

--- a/src/pytest_matcher/plugin.py
+++ b/src/pytest_matcher/plugin.py
@@ -18,8 +18,8 @@ import re
 import shutil
 import sys
 import urllib.parse
-from typing import Final, TextIO, cast
 from dataclasses import dataclass
+from typing import Final, TextIO, cast
 
 # Third party packages
 import pytest

--- a/src/pytest_matcher/plugin.py
+++ b/src/pytest_matcher/plugin.py
@@ -56,7 +56,7 @@ class _MismatchStyle(enum.Enum):
 
 
 @dataclass
-class _ContentMatchResult:
+class _ContentMatchResult:                                  # NOQA: PLW1641
     """Result of matching text content against a regex."""
 
     result: bool
@@ -84,7 +84,7 @@ class _ContentMatchResult:
           ]
 
 
-class _ContentCheckOrStorePattern:
+class _ContentCheckOrStorePattern:                          # NOQA: PLW1641
 
     def __init__(self, filename: pathlib.Path, *, store: bool) -> None:
         self._pattern_filename = filename
@@ -289,7 +289,7 @@ def expected_err(request: pytest.FixtureRequest) -> _ContentCheckOrStorePattern:
       )
 
 
-class _YAMLCheckOrStorePattern:
+class _YAMLCheckOrStorePattern:                             # NOQA: PLW1641
 
     def __init__(self, filename: pathlib.Path, *, store: bool) -> None:
         self._expected_file = filename


### PR DESCRIPTION
## Summary
- refactor `_ContentMatchResult` into a dataclass
- adjust equality and boolean methods to use new fields

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686ee7588b9083238bb8a32f039acfe3