### PR TITLE
Fix grammar in docs and docstrings

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -45,7 +45,7 @@ Added
 Fixed
 -----
 
-- Release GitHub workflow has been fixed to use modern versions of involved actions.
+- The release GitHub workflow has been updated to use modern versions of the involved actions.
 - Do not override the path suffix-like part (separated by a dot) with a pattern
   filename extension.
 
@@ -70,7 +70,7 @@ Fixed
 
 - **BREAKING CHANGE** The expectation files path has never used the
   ``<test-module-name>`` component despite the :file:`README.rst` claimed.
-  Existed projects could set :option:`pm-pattern-file-fmt` to
+  Existing projects could set :option:`pm-pattern-file-fmt` to
   ``{class}/{fn}{callspec}`` to preserve backward compatibility.
 
 Removed

--- a/README.rst
+++ b/README.rst
@@ -6,20 +6,20 @@ What is this
 
 |Latest Release| |nbsp| |Tests|
 
-This is a ``pytest`` plugin provides a couple of fixtures to match test output against patterns
-stored in files. Expectations/pattern files are stored in a base directory, and additional
-paths are based on the test module name, test class name, and test function name::
+This is a ``pytest`` plugin that provides a couple of fixtures to match test output against
+patterns stored in files. Expectation files are placed in a base directory, and additional
+paths are derived from the test module name, test class name and test function name::
 
     <base-dir>/<test-module-name>/[test-class-name/]<test-function-name>[[<callspec-id>]]
 
-Having output expectations/pattern files separate from tests helps to reduce the code of the
-latter and match the output more than just a few lines.
+Keeping the expectation files separate from tests reduces the amount of test code and makes
+it possible to match more than just a few lines of output.
 
 
 Documentation
 -------------
 
-The latest documentation could be found `here <https://pytest-matcher.readthedocs.io>`_.
+The latest documentation can be found `here <https://pytest-matcher.readthedocs.io>`_.
 
 
 See Also

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -27,7 +27,7 @@ Fixture
     .. py:function:: expected_err.match(output: str) -> bool
 
         If the output contains data that changes from run to run (such as timestamps or paths),
-        edit the expectation file using regular expressions and match it with this function.
+        edit the expectation file to use regular expressions and match it with this function.
         See :ref:`Getting Started <match-regex>` for more details.
 
         .. code-block:: python

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -12,8 +12,8 @@ Fixture
 .. py:data:: expected_out
 .. py:data:: expected_err
 
-    This fixture provides an easy way to test captured ``STDOUT``/``STDERR``.
-    To match a static output, one can use a trivial ``assert``:
+    This fixture makes it easy to test captured ``STDOUT`` and ``STDERR``.
+    To match static output, simply use an ``assert``:
 
     .. code-block:: python
 
@@ -26,9 +26,9 @@ Fixture
     .. py:function:: expected_out.match(output: str) -> bool
     .. py:function:: expected_err.match(output: str) -> bool
 
-        If the output has data changed from run to run (like timestamps or paths), one can edit the
-        expected output file using regular expressions and use this function to match them.
-        Please see :ref:`Getting Started <match-regex>` for more information about this topic.
+        If the output contains data that changes from run to run (such as timestamps or paths),
+        edit the expectation file using regular expressions and match it with this function.
+        See :ref:`Getting Started <match-regex>` for more details.
 
         .. code-block:: python
             :emphasize-lines: 4
@@ -39,14 +39,12 @@ Fixture
                 assert expected_out.match(stdout) == True
 
         .. note::
-            The plugin provides elaborate output on assert failure, but to make it work, one
-            should use an explicit check for the ``True`` value of the ``expected_out.match(…)``
-            result.
+            The plugin provides detailed output on assertion failure, but it only works if you
+            explicitly check for ``True`` from ``expected_out.match(…)``.
 
 .. py:data:: expected_yaml
 
-    This fixture provides an easy way to check if the output YAML data matches
-    the expectations.
+    This fixture provides an easy way to verify that YAML output matches the expectations.
 
     .. todo::
         More docs on this!
@@ -57,11 +55,11 @@ Marker
 
 .. py:function:: expect_suffix(*args: str, suffix: str)
 
-    If output may have system-specific content (e.g., different EOL styles), adding an arbitrary
-    system-specific suffix to the pattern file makes storing different variants in separate files
-    possible.  Arguments to the marker will be ``%XX``-escaped, dash-concatenated and prefixed with
-    leading ``-`` and then used as the ``{suffix}`` placeholder of the :option:`pm-pattern-file-fmt`
-    option.
+    If output may contain system-specific content (e.g., different EOL styles), you can add an
+    arbitrary system-specific suffix to the pattern file so that different variants are stored in
+    separate files.  Arguments to the marker are ``%XX``-escaped, dash-concatenated and prefixed with
+    a leading ``-``. They are then used as the ``{suffix}`` placeholder of the
+    :option:`pm-pattern-file-fmt` option.
 
     Usage example:
 

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -15,7 +15,7 @@ Plugin Command Line Options
 
 .. option:: --pm-patterns-base-dir <DIR>
 
-    Specify the base directory used to find expectation or pattern files.
+    Specify the base directory used to find expectation/pattern files.
     See also :option:`pm-patterns-base-dir`.
 
 

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -10,24 +10,24 @@ Plugin Command Line Options
 
 .. option:: --pm-mismatch-style <diff|full>
 
-    Overrides the value of :option:`pm-mismatch-style` configuration parameter.
+    Override the value of the :option:`pm-mismatch-style` configuration parameter.
 
 
 .. option:: --pm-patterns-base-dir <DIR>
 
-    Specify the base directory to find expectation/pattern files.
+    Specify the base directory used to find expectation or pattern files.
     See also :option:`pm-patterns-base-dir`.
 
 
 .. option:: --pm-reveal-unused-files
 
-    Reveal and print unused pattern files.  If :envvar:`PYTEST_MATCHER_RETURN_CODES`
-    environment variable is set to the *true value* (one of ``1``, ``true``, ``yes``)
-    and found any unused pattern files, the exit code will be ``1``.
-    The tests will not run.
+    Reveal and print unused pattern files. If the environment variable
+    :envvar:`PYTEST_MATCHER_RETURN_CODES` is set to a true value (one of ``1``,
+    ``true``, ``yes``) and any unused pattern files are found, the exit code will be ``1``.
+    Tests will not run.
 
 
 .. option:: --pm-save-patterns
 
-    Write the captured output to the expectations file instead of performing actual tests.
-    The option helps collect initial content to match in further tests and skips the test.
+    Write the captured output to the expectation file instead of performing the test.
+    This option helps collect the initial pattern and skips the test.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -15,17 +15,17 @@ The following options can be set in the `Pytest configuration file`_.
     :Choice: ``full``, ``diff``
     :Default: ``full``
 
-    In case of expected output mismatch, specifies how to report a test failure:
+    When the expected output does not match, this option controls how the failure is reported:
 
-    - ``full`` -- shows actual and expected separately (default).
-    - ``diff`` -- shows a unified diff between actual and expected text.
+    - ``full`` -- show actual and expected output separately (default).
+    - ``diff`` -- show a unified diff between actual and expected text.
 
 
 .. option:: pm-pattern-file-fmt
 
     :Default: ``{module}/{class}/{fn}{callspec}{suffix}``
 
-    Expectations filename pattern format. It can have the following placeholders:
+    Expectation filename pattern. It can contain the following placeholders:
 
     - ``{module}`` for the test module name.
     - ``{class}`` for the test class name.
@@ -33,17 +33,17 @@ The following options can be set in the `Pytest configuration file`_.
     - ``{callspec}`` for the parameterized part of the test function.
     - ``{suffix}`` for the optional suffix added by the :py:func:`expect_suffix` mark.
 
-    Note that for non-class test functions, the ``{class}`` placeholder part will be empty.
-    For parametrized tests, the ``{callspec}`` placeholder containing ``%XX``-escaped information
-    about the parametrization is added.
+    Note that for non-class test functions, the ``{class}`` placeholder will be empty.
+    For parametrized tests, the ``{callspec}`` placeholder contains ``%XX``-escaped information
+    about the parametrization.
 
 
 .. option:: pm-patterns-base-dir
 
     :Default: :file:`test/data/expected`
 
-    The base directory is used to place expectations/pattern files.
-    Given directory must be relative to the project's root.
+    The base directory used for expectation/pattern files.
+    The directory must be relative to the project's root.
 
 
 .. _Pytest configuration file: https://docs.pytest.org/en/8.0.x/reference/customize.html

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -6,26 +6,26 @@ Getting Started
 
 .. program:: pytest-matcher
 
-Install the package in the variant you want:
+Install the package using the variant you want:
 
 .. code-block:: console
 
     $ pip install pytest-matcher
 
-or with ``diff`` mode highlighted with ``Pygments``:
+or with ``diff`` mode highlighted via ``Pygments``:
 
 .. code-block:: console
 
     $ pip install pytest-matcher[pygments]
 
-The plugin provides :py:data:`expected_out` and :py:data:`expected_err` named fixture functions.
-The usage is trivial as the following:
+The plugin provides the fixtures :py:data:`expected_out` and :py:data:`expected_err`.
+Usage is straightforward as shown below:
 
 .. literalinclude:: ../test/test_foo.py
     :language: python
     :pyobject: test_foo
 
-If you run :command:`pytest` now, it'll skip the test due to a missed output expectations file:
+If you run :command:`pytest` now, the test will be skipped because the expectation file is missing:
 
 .. code-block:: console
     :emphasize-lines: 5,6
@@ -41,8 +41,8 @@ If you run :command:`pytest` now, it'll skip the test due to a missed output exp
 
 
 Add the :option:`pm-patterns-base-dir` option to the `Pytest configuration file`_
-pointing, for example, to :file:`test/data/expected`.  Add the :option:`--pm-save-patterns`
-:command:`pytest` CLI option to write the initial output expectations file:
+pointing, for example, to :file:`test/data/expected`. Run :command:`pytest` with
+the :option:`--pm-save-patterns` option to write the initial expectation file:
 
 .. code-block:: console
     :emphasize-lines: 5,6
@@ -60,13 +60,13 @@ Review the stored pattern file :file:`test/data/expected/test_foo/test_foo.out` 
 
 .. note::
 
-    It’s recommended that the exact test name(s) be specified when writing the expectations file.
-    Otherwise, the plugin will overwrite all files that are most likely not what you want ;-)
+    It’s recommended that you specify the exact test name(s) when writing the expectation file.
+    Otherwise the plugin will overwrite all files, which is probably not what you want ;-)
 
 
 
-Now, when the expected output file exists, you can rerun :command:`pytest` to see that the test output
-is matching expectations:
+Now that the expected output file exists, rerun :command:`pytest` to see that the test
+output matches expectations:
 
 .. code-block:: console
     :emphasize-lines: 5
@@ -82,14 +82,14 @@ is matching expectations:
 
 .. _match-regex:
 
-If the captured output has something that could change from run to run, for example, timestamps
-or filesystem paths, it's possible to match the output using regular expressions:
+If the captured output contains values that change from run to run, for example timestamps
+or filesystem paths, you can match the output using regular expressions:
 
 .. literalinclude:: ../test/test_foo.py
     :language: python
     :pyobject: test_regex
 
-Store the pattern file for this test and rerun :command:`pytest` with ``-vv`` option:
+Store the pattern file for this test and rerun :command:`pytest` with the ``-vv`` option:
 
 .. code-block:: console
     :emphasize-lines: 24,28
@@ -130,7 +130,7 @@ Store the pattern file for this test and rerun :command:`pytest` with ``-vv`` op
     FAILED test/test_foo.py::test_regex - AssertionError: assert
     ============================== 1 failed in 0.03s ===============================
 
-To make it match, edit the expected output file and replace changing parts with regular
+To make it match, edit the expectation file and replace the changing parts with regular
 expressions:
 
 .. code-block::
@@ -139,7 +139,7 @@ expressions:
     Current date: [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?
     Current module: .*/test/test_foo.py
 
-Now the test will pass:
+The test will now pass:
 
 .. code-block:: console
     :emphasize-lines: 5

--- a/doc/include-traversal-warning.rst
+++ b/doc/include-traversal-warning.rst
@@ -3,7 +3,7 @@
 
 .. attention::
 
-    Directory traversal is not allowed for path parameters!  Also, paths should be relative.
-    They get evaluated relative to the ``rootdir`` determined_ by ``pytest``.
+    Directory traversal is not allowed for path parameters and paths must be relative.
+    They are evaluated relative to the ``rootdir`` determined_ by ``pytest``.
 
 .. _determined: https://docs.pytest.org/en/8.0.x/reference/customize.html#initialization-determining-rootdir-and-configfile

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,11 +6,11 @@
 Welcome to Pytest Matcher documentation!
 ========================================
 
-This is a ``pytest`` plugin provides a couple of fixtures to match test output against patterns
-stored in files.  Expectations/pattern files are stored in a base directory, and additional
-paths are based on the test module name, test class name, and test function name.  Having output
-expectations/pattern files separate from tests helps to reduce the code of the latter and match
-the output more than just a few lines.
+This is a ``pytest`` plugin that provides a couple of fixtures to match test output against
+patterns stored in files. Expectation files are kept in a base directory, and additional
+paths are derived from the test module name, test class name and test function name. Keeping
+expectation files separate from tests reduces test code and allows matching more than just a
+few lines of output.
 
 .. toctree::
     :maxdepth: 1

--- a/src/pytest_matcher/__init__.py
+++ b/src/pytest_matcher/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-"""`pytest` plugin to match test output against expectations stored in files."""
+"""A ``pytest`` plugin for matching test output against expectation files."""
 
 # Local imports
 from .plugin import expected_err, expected_out, pytest_addoption

--- a/src/pytest_matcher/plugin.py
+++ b/src/pytest_matcher/plugin.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-"""A `pytest` plugin to match test output against expectations."""
+"""A ``pytest`` plugin that matches test output against expectation files."""
 
 from __future__ import annotations
 
@@ -36,7 +36,7 @@ try:
 except ImportError:
     HAVE_PYGMENTS = False
     def should_do_markup(_: TextIO) -> bool:                # type: ignore[misc]
-        """A dummy stub if not possible to import smth."""
+        """Fallback stub used when the optional dependency cannot be imported."""
         return False
 
 
@@ -57,7 +57,7 @@ class _MismatchStyle(enum.Enum):
 
 @dataclass
 class _ContentMatchResult:                                  # NOQA: PLW1641
-    """Result of matching text content against a regex."""
+    """Result of matching text content against a regular expression."""
 
     result: bool
     text: list[str]
@@ -233,7 +233,7 @@ def _make_expected_filename(request: pytest.FixtureRequest, ext: str) -> pathlib
 
     # Make sure base directory exists
     if not result.exists():
-        pytest.skip(f'Base directory for pattern-matcher do not exists: `{result}`')
+        pytest.skip(f'Base directory for pattern-matcher does not exist: `{result}`')
 
     # Check if a test function has been marked as having a
     # suffix for a pattern filename.
@@ -273,7 +273,7 @@ def _make_expected_filename(request: pytest.FixtureRequest, ext: str) -> pathlib
 
 @pytest.fixture
 def expected_out(request: pytest.FixtureRequest) -> _ContentCheckOrStorePattern:
-    """A pytest fixture to match `STDOUT` against a file."""
+    """Pytest fixture for matching ``STDOUT`` against a file."""
     return _ContentCheckOrStorePattern(
         _make_expected_filename(request, '.out')
       , store=request.config.getoption('--pm-save-patterns')
@@ -282,7 +282,7 @@ def expected_out(request: pytest.FixtureRequest) -> _ContentCheckOrStorePattern:
 
 @pytest.fixture
 def expected_err(request: pytest.FixtureRequest) -> _ContentCheckOrStorePattern:
-    """A pytest fixture to match `STDERR` against a file."""
+    """Pytest fixture for matching ``STDERR`` against a file."""
     return _ContentCheckOrStorePattern(
         _make_expected_filename(request, '.err')
       , store=request.config.getoption('--pm-save-patterns')
@@ -342,7 +342,7 @@ class _YAMLCheckOrStorePattern:                             # NOQA: PLW1641
 
 @pytest.fixture
 def expected_yaml(request: pytest.FixtureRequest) -> _YAMLCheckOrStorePattern:
-    """A pytest fixture to match YAML file content."""
+    """Pytest fixture for matching YAML file content."""
     return _YAMLCheckOrStorePattern(
         _make_expected_filename(request, '.yaml')
       , store=request.config.getoption('--pm-save-patterns')
@@ -350,12 +350,12 @@ def expected_yaml(request: pytest.FixtureRequest) -> _YAMLCheckOrStorePattern:
 
 
 class _UnusedFilesReporter:
-    """A reporter to reveal unused pattern files."""
+    """Reporter that reveals unused pattern files."""
     def __init__(self, *, return_codes: bool = False) -> None:
         self._return_codes = return_codes
 
     def pytest_collection_finish(self, session: pytest.Session) -> None:
-        """Once test items have been collected, check for and show unused files."""
+        """Check for and display unused files after collection."""
         if not session.items:
             return
 
@@ -398,7 +398,7 @@ def pytest_assertrepr_compare(                              # NOQA: PLR0911
   , left: object
   , right: object
   ) -> list[str] | None:
-    """Hook into comparison failure."""
+    """Hook executed when assertion comparisons fail."""
     if op == '==':
         match left, right:
             case _ContentMatchResult() as left, bool(right):
@@ -435,7 +435,7 @@ def pytest_assertrepr_compare(                              # NOQA: PLR0911
 
 # Add CLI option
 def pytest_addoption(parser: pytest.Parser) -> None:
-    """Add plugin options to CLI and the configuration file."""
+    """Add plugin options to the command-line interface and configuration file."""
     group = parser.getgroup('pattern matcher')
     group.addoption(
         '--pm-save-patterns'
@@ -483,7 +483,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config: pytest.Config) -> None:
-    """Validate configuration and register additional reporter."""
+    """Validate the configuration and register the unused-files reporter."""
     config.addinivalue_line(
         'markers'
       , 'expect_suffix(args..., *, suffix="..."): mark test to have suffixed pattern file'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-"""Fixtures."""
+"""Test fixtures."""
 
 # Standard imports
 import pathlib
@@ -40,7 +40,7 @@ class _ExpectDir:
 
 @pytest.fixture
 def ourtestdir(pytester: pytest.Pytester) -> pytest.Pytester:
-    """Pytest fixture to write a sample `pytest.ini` w/ `pm-patterns-base-dir` preset."""
+    """Pytest fixture that writes a sample ``pytest.ini`` with ``pm-patterns-base-dir`` preset."""
     pytester.makefile(
         '.ini'
       , pytest="""
@@ -54,7 +54,7 @@ def ourtestdir(pytester: pytest.Pytester) -> pytest.Pytester:
 
 @pytest.fixture
 def expectdir(pytester: pytest.Pytester, request: pytest.FixtureRequest) -> _ExpectDir:
-    """Pytest fixture to write sample pattern files."""
+    """Pytest fixture that writes sample pattern files."""
     path = pytester.path / request.function.__name__
     path.mkdir()
     return _ExpectDir(path)

--- a/test/test_foo.py
+++ b/test/test_foo.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-"""Demo tests."""
+"""Demonstration tests."""
 
 # Standard imports
 from datetime import datetime
@@ -13,7 +13,7 @@ import pytest
 
 
 def test_foo(capfd, expected_out) -> None:
-    """Plain text demo test."""
+    """Plain text demonstration test."""
     print('foo')
 
     stdout, _ = capfd.readouterr()
@@ -22,7 +22,7 @@ def test_foo(capfd, expected_out) -> None:
 
 
 def test_regex(capfd, expected_out) -> None:
-    """Regex demo test."""
+    """Regular-expression demonstration test."""
     print(f'Current date: {datetime.now()}')
     print(f'Current module: {__file__}')
 
@@ -33,7 +33,7 @@ def test_regex(capfd, expected_out) -> None:
 
 @pytest.mark.xfail(reason='Demo for diff show')
 def test_diff(capfd, expected_out) -> None:
-    """Plain text demo test with diff."""
+    """Plain text demonstration test that shows diff output."""
     print('Hello Africa!\nHow are you doing?', end='')
 
     stdout, _ = capfd.readouterr()


### PR DESCRIPTION
## Summary
- polish RST documentation
- improve grammar of Python docstrings
- tweak wording of some error messages

## Testing
- `hatch run test`
- `hatch run spell-check`
- `hatch run lint-check`
- `hatch run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6873047d15b8832399ac6fe02deecb86