### PR TITLE
feat: introduce the `--pm-fail-on-unused-files` option

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -23,6 +23,14 @@ to `Semantic Versioning`_.
 
 .. program:: pytest-matcher
 
+Unreleased_
+===========
+
+Added
+-----
+
+- Introduce the :option:`--pm-fail-on-unused-files` option.
+
 
 2.0.2_ -- 2024-08-01
 ====================

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -12,20 +12,22 @@ Plugin Command Line Options
 
     Override the value of the :option:`pm-mismatch-style` configuration parameter.
 
-
 .. option:: --pm-patterns-base-dir <DIR>
 
     Specify the base directory used to find expectation/pattern files.
     See also :option:`pm-patterns-base-dir`.
 
-
 .. option:: --pm-reveal-unused-files
 
-    Reveal and print unused pattern files. If the environment variable
-    :envvar:`PYTEST_MATCHER_RETURN_CODES` is set to a true value (one of ``1``,
-    ``true``, ``yes``) and any unused pattern files are found, the exit code will be ``1``.
-    Tests will not run.
+    Reveal and print unused pattern files.  The tests will not run.
 
+.. option:: --pm-fail-on-unused-files
+
+    If unused expectaation file(s) have found by the :option:`!--pm-reveal-unused-files`
+    option, exit with failure code ``1``.
+
+    Also, the :envvar:`PYTEST_MATCHER_RETURN_CODES` environment variable can be set to the
+    *true value* (one of ``1``, ``true``, ``yes``) for the same effect.
 
 .. option:: --pm-save-patterns
 

--- a/src/pytest_matcher/plugin.py
+++ b/src/pytest_matcher/plugin.py
@@ -462,6 +462,11 @@ def pytest_addoption(parser: pytest.Parser) -> None:
       , action='store_true'
       , help='reveal and print unused pattern files'
       )
+    group.addoption(
+        '--pm-fail-on-unused-files'
+      , action='store_true'
+      , help='exit with fail if unused pattern files found'
+      )
 
     # Also add INI file (TOML table) options
     parser.addini(
@@ -520,7 +525,8 @@ def pytest_configure(config: pytest.Config) -> None:
     if not config.getoption('--pm-reveal-unused-files'):
         return
 
-    return_codes = os.getenv('PYTEST_MATCHER_RETURN_CODES', '').lower() in ('yes', 'true', '1')
+    return_codes = os.getenv('PYTEST_MATCHER_RETURN_CODES', '').lower() in ('yes', 'true', '1') \
+      or config.getoption('--pm-fail-on-unused-files')
     config.option.collectonly = True
     reporter = _UnusedFilesReporter(return_codes=return_codes)
     config.pluginmanager.unregister(name='terminalreporter')


### PR DESCRIPTION
# Changes in this PR

If unused expectaation file(s) have found by the `--pm-reveal-unused-files`
option, exit with failure code `1`.
