### PR TITLE
Improve user-facing messages

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -14,7 +14,7 @@ Plugin Command Line Options
 
 .. option:: --pm-patterns-base-dir <DIR>
 
-    Specify the base directory used to find expectation/pattern files.
+    Base directory used for storing pattern files.
     See also :option:`pm-patterns-base-dir`.
 
 .. option:: --pm-reveal-unused-files
@@ -31,5 +31,5 @@ Plugin Command Line Options
 
 .. option:: --pm-save-patterns
 
-    Write the captured output to the expectation file instead of performing the test.
-    This option helps collect the initial pattern and skips the test.
+    Save captured output to pattern files and skip the test.
+    Use this option to collect initial content for future comparisons.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -42,7 +42,7 @@ The following options can be set in the `Pytest configuration file`_.
 
     :Default: :file:`test/data/expected`
 
-    The base directory used for expectation/pattern files.
+    Base directory used for storing pattern files.
     The directory must be relative to the project's root.
 
 

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -35,7 +35,7 @@ If you run :command:`pytest` now, the test will be skipped because the expectati
     collected 1 item
 
     test/test_foo.py::test_foo SKIPPED (Base directory for pattern-matcher
-    do not exists: `…/pytest-matcher/master/test/data/expected`)               [100%]
+    does not exist: `…/pytest-matcher/master/test/data/expected`)               [100%]
 
     ============================== 1 skipped in 0.01s ==============================
 
@@ -51,7 +51,7 @@ the :option:`--pm-save-patterns` option to write the initial expectation file:
     ============================= test session starts ==============================
     collecting ... collected 1 item
 
-    test/test_foo.py::test_foo SKIPPED (Pattern file has been saved
+    test/test_foo.py::test_foo SKIPPED (Pattern file saved to
     `…/pytest-matcher/master/test/data/expected/test_foo/test_foo.out`)       [100%]
 
     ============================== 1 skipped in 0.02s ==============================
@@ -114,7 +114,7 @@ Store the pattern file for this test and rerun :command:`pytest` with the ``-vv`
 
     >       assert expected_out.match(stdout) ==True
     E       AssertionError: assert
-    E         The test output doesn't match to the expected regex
+    E         The test output doesn't match the expected regex.
     E         (from `…/pytest-matcher/master/test/data/expected/test_foo/test_regex.out`):
     E         ---[BEGIN actual output]---
     E         Current date: 2024-03-02 21:59:03.792447

--- a/src/pytest_matcher/plugin.py
+++ b/src/pytest_matcher/plugin.py
@@ -73,7 +73,7 @@ class _ContentMatchResult:                                  # NOQA: PLW1641
     def report_regex_mismatch(self) -> list[str]:
         return [
             ''
-          , "The test output doesn't match to the expected regex"
+          , "The test output doesn't match the expected regex."
           , f'(from `{self.filename}`):'
           , '---[BEGIN actual output]---'
           , *self.text
@@ -103,7 +103,7 @@ class _ContentCheckOrStorePattern:                          # NOQA: PLW1641
         self.pattern_filename.write_text(text)
 
         # Also mark the test as skipped!
-        pytest.skip(f'Pattern file has been saved `{self.pattern_filename}`')
+        pytest.skip(f'Pattern file saved to `{self.pattern_filename}`.')
 
     def _read_expected_file_content(self) -> None:
         if not (self.pattern_filename.exists() and self.pattern_filename.is_file()):
@@ -136,7 +136,9 @@ class _ContentCheckOrStorePattern:                          # NOQA: PLW1641
                 what = re.compile(content, flags=flags)
 
         except re.error as ex:
-            pytest.skip(f'Compile a regular expression from the pattern has failed: {ex!s}')
+            pytest.skip(
+                f'Compiling the regular expression from the pattern failed: {ex!s}'
+            )
 
         text_lines = text.splitlines()
 
@@ -156,7 +158,7 @@ class _ContentCheckOrStorePattern:                          # NOQA: PLW1641
         expected = self.expected_file_content
         return [
             ''
-          , "The test output doesn't equal to the expected"
+          , "The test output doesn't match the expected output."
           , f'(from `{self.pattern_filename}`):'
           , '---[BEGIN actual output]---'
           , *self._make_newlines_visible(actual).splitlines()
@@ -195,7 +197,7 @@ class _ContentCheckOrStorePattern:                          # NOQA: PLW1641
 
         return [
             ''
-          , "The test output doesn't equal to the expected"
+          , "The test output doesn't match the expected output."
           , f'(from `{self.pattern_filename}`):'
           , '---[BEGIN expected vs actual diff]---'
           , *diff
@@ -332,7 +334,7 @@ class _YAMLCheckOrStorePattern:                             # NOQA: PLW1641
         assert self.expected is not None
         return [
             ''
-          , f'Comparing the test result (`{actual}`) and the expected (`{self.expected_file}`) YAML files:'
+          , f'Comparing the test result (`{actual}`) with the expected YAML file (`{self.expected_file}`):'
           , '---[BEGIN actual result]---'
           , repr(self.result)
           , '---[END actual result]---'
@@ -442,19 +444,19 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     group.addoption(
         '--pm-save-patterns'
       , action='store_true'
-      , help='write captured output to pattern files and skip the test'
+      , help='Save captured output to pattern files and skip the test.'
       )
     group.addoption(
         '--pm-mismatch-style'
       , type=str
-      , help='output style on expected/actual mismatch'
+      , help='Style of the mismatch report when expected and actual outputs differ.'
       , choices=[style.name.lower() for style in _MismatchStyle]
       , default=None
       )
     group.addoption(
         '--pm-patterns-base-dir'
       , metavar='PATH'
-      , help='base directory to read/write pattern files'
+      , help='Base directory used for storing pattern files.'
       , type=pathlib.Path
       )
     group.addoption(
@@ -471,7 +473,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     # Also add INI file (TOML table) options
     parser.addini(
         'pm-patterns-base-dir'
-      , help='base directory to read/write pattern files'
+      , help='Base directory used for storing pattern files.'
       , default=pathlib.Path('test/data/expected')
       )
     parser.addini(
@@ -482,7 +484,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
       )
     parser.addini(
         'pm-mismatch-style'
-      , help='output style on expected/actual mismatch'
+      , help='Style of the mismatch report when expected and actual outputs differ.'
       , type='string'
       , default=_MismatchStyle.FULL.name.lower()
       )

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -109,7 +109,7 @@ def regex_fail_match_test(ourtestdir, expectdir) -> None:
     result = ourtestdir.runpytest()
     result.assert_outcomes(failed=1)
     result.stdout.re_match_lines([
-        ".*The test output doesn't match to the expected regex"
+        ".*The test output doesn't match the expected regex."
       ])
 
 


### PR DESCRIPTION
## Summary
- clarify regex mismatch and mismatch output messages
- reword pattern save notice and base directory error
- polish CLI option descriptions
- update docs and tests for new text

## Testing
- `pip install -e .[pygments]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687326ad13548323b27f6dc9dba03518